### PR TITLE
Added secrets.py to gitignore and template for secrets.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ webpack-stats.json
 .venv-python2
 cars
 patron_sql_tests.sql
+
+# Secrets file
+rocket_league/settings/secrets.py
+

--- a/rocket_league/settings/secrets.py.bak
+++ b/rocket_league/settings/secrets.py.bak
@@ -1,0 +1,28 @@
+import os
+
+os.environ['TWITTER_API_KEY'] = ''
+os.environ['TWITTER_API_SECRET'] = ''
+os.environ['TWITTER_ACCESS_TOKEN'] = ''
+os.environ['TWITTER_ACCESS_SECRET'] = ''
+
+os.environ['REDDIT_USERNAME'] = ''
+os.environ['REDDIT_PASSWORD'] = ''
+
+os.environ['DATABASE_USER'] = ''
+os.environ['DATABASE_PASSWORD'] = ''
+os.environ['DATABASE_HOST'] = ''
+
+os.environ['AWS_ACCESS_KEY_ID'] = ''
+os.environ['AWS_SECRET_ACCESS_KEY'] = ''
+
+os.environ['PATREON_CLIENT_ID'] = ''
+os.environ['PATREON_CLIENT_SECRET'] = ''
+os.environ['PATREON_ACCESS_TOKEN'] = ''
+os.environ['PATREON_REFRESH_TOKEN'] = ''
+
+os.environ['SLACK_URL'] = ''
+
+os.environ['REDIS_MASTER_PASSWORD'] = ''
+os.environ['REDIS_SLAVE_PASSWORD'] = ''
+os.environ['REDIS_HOST'] = ''
+


### PR DESCRIPTION
The Readme points out that we shouldn't be adding `secrets.py` to version control, so I've added it to `.gitignore` and put a template in the `rocket_league/settings/` directory.

This way we can easily copy `secrets.py` into place, and we don't have to worry about accidentally sharing our API keys.